### PR TITLE
Fix hasCartPerms 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.bergerkiller.bukkit</groupId>
             <artifactId>BKCommonLib</artifactId>
-            <version>1.62-SNAPSHOT</version>
+            <version>1.63-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix: NPE on digits or invalid minecart types
Enhancement: Prevent 0 length and other invalid trains with useful error messages

This fix allows spawner signs with digits in them to work without NPE and presents more useful warnings and error messages to the player when wrong syntax is used in specifying the minecarts for a train.

Example: "2m"
Before: NPE
After: Works as intended

Example: "z"
Before: NPE
After: Message that minecart type "z" is invalid and sign is not created

Example: "0m"
Before: NPE (and if NPE was fixed, sign could be created)
After: Error that train has no valid minecarts and sign is not created

Example: "0h2m"
Before: NPE (and if NPE was fixed, sign could be created)
After: Sign is still created but with warning that there are 0 carts of type "h" in the train
