### PR TITLE
Add and implement parseOldSigns option for signs from Minecraft <= 1.7

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/TrainCarts.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/TrainCarts.java
@@ -82,6 +82,7 @@ public class TrainCarts extends PluginBase {
     public static boolean SignLinkEnabled = false;
     public static boolean MinecartManiaEnabled = false;
     public static boolean MyWorldsEnabled = false;
+    public static boolean parseOldSigns;
     public static TrainCarts plugin;
     private static String currencyFormat;
     private static Task fixGroupTickTask;
@@ -396,6 +397,18 @@ public class TrainCarts extends PluginBase {
         //parser shortcuts
         config.setHeader("itemShortcuts", "\nSeveral shortcuts you can use on signs to set the items");
         ConfigurationNode itemshort = config.getNode("itemShortcuts");
+
+        /*
+         * Signs created before Minecraft 1.8 with (for example) "[train]" will have the brackets stripped.
+         * TrainCarts will not recognize these causing trains to ignore all "old" signs in the world.
+         * Here is a flag to recognize "train" and "!train" etc. on the top line of signs and re-add in
+         * the missing [].
+         */
+        config.setHeader("parseOldSigns", "\nParse signs made in Minecraft 1.7 and before without re-creating");
+        if (config.contains("parseOldSigns")) {
+            parseOldSigns = config.get("parseOldSigns", false);
+        }
+
         parsers.clear();
 
         // ================= Defaults ===============

--- a/src/main/java/com/bergerkiller/bukkit/tc/events/SignActionEvent.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/events/SignActionEvent.java
@@ -6,6 +6,7 @@ import com.bergerkiller.bukkit.common.utils.LogicUtil;
 import com.bergerkiller.bukkit.common.utils.MaterialUtil;
 import com.bergerkiller.bukkit.tc.Direction;
 import com.bergerkiller.bukkit.tc.PowerState;
+import com.bergerkiller.bukkit.tc.TrainCarts;
 import com.bergerkiller.bukkit.tc.Util;
 import com.bergerkiller.bukkit.tc.controller.MinecartGroup;
 import com.bergerkiller.bukkit.tc.controller.MinecartMember;
@@ -83,6 +84,9 @@ public class SignActionEvent extends Event implements Cancellable {
             return;
         } else {
             // Sign available - initialize the sign
+            if (TrainCarts.parseOldSigns) {
+                convertFirstLine();
+            }
             mainLine = this.getLine(0);
             this.poweron = mainLine.startsWith("[+");
             this.powerinv = mainLine.startsWith("[!");
@@ -649,6 +653,18 @@ public class SignActionEvent extends Event implements Cancellable {
             return members;
         }
         return Collections.EMPTY_LIST;
+    }
+
+    /*
+     * Add [] around first line, if [] are not present and first line
+     * looks like a valid TrainCarts sign.
+     */
+    public void convertFirstLine() {
+        String firstLineOriginal = this.sign.getLine(0);
+        String firstLineConverted = SignActionMode.convertOldSignString(firstLineOriginal);
+        if (! firstLineOriginal.equals(firstLineConverted)) {
+            this.setLine(0, firstLineConverted);
+        }
     }
 
     public String getLine(int index) {

--- a/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionMode.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionMode.java
@@ -1,5 +1,6 @@
 package com.bergerkiller.bukkit.tc.signactions;
 
+import com.bergerkiller.bukkit.tc.TrainCarts;
 import com.bergerkiller.bukkit.tc.events.SignActionEvent;
 import org.bukkit.block.Sign;
 import org.bukkit.event.block.SignChangeEvent;
@@ -7,7 +8,8 @@ import org.bukkit.event.block.SignChangeEvent;
 public enum SignActionMode {
     TRAIN, CART, RCTRAIN, NONE;
 
-    public static SignActionMode fromString(String name) {
+    public static SignActionMode fromString(String nameIn) {
+        String name = convertOldSignString(nameIn);
         if (name.endsWith("]") && name.startsWith("[")) {
             name = name.substring(1, name.length() - 1);
             if (name.startsWith("!") || name.startsWith("+")) {
@@ -38,5 +40,33 @@ public enum SignActionMode {
 
     public static SignActionMode fromEvent(SignChangeEvent event) {
         return fromString(event.getLine(0));
+    }
+
+    /*
+     * Going from Minecraft 1.7 to 1.8, signs with "[ ... ]" had the [] removed.
+     * Set configuration option parseOldSigns = true if you are upgrading from an
+     * older version to 1.8 and you want your old signs to work. This code adds back
+     * [] to things that "look like" train signs.
+     */
+
+    public static String convertOldSignString(String nameIn) {
+        if (!TrainCarts.parseOldSigns) {
+            return nameIn;
+        }
+        if (nameIn.endsWith("]") && nameIn.startsWith("[")) {
+            return nameIn;
+        }
+        if (nameIn.length() >= 15) {
+            // Adding [ ] would make the line too long (16 characters per line)
+            return nameIn;
+        }
+        String name = nameIn;
+        if (name.startsWith("!") || name.startsWith("+")) {
+            name = name.substring(1);
+        }
+        if (name.startsWith("train") || name.startsWith("t ") || name.startsWith("cart")) {
+            return String.format("[%s]", nameIn);
+        }
+        return nameIn;
     }
 }


### PR DESCRIPTION
Going from 1.7 to 1.8.7 all of the signs that previously started with "[train]" or "[!train]" got converted to just "train" or "!train" -- the [ ] were stripped off. (Probably related to the new JSON support because [ ] is a JSON array.)

[ ] that are added in 1.8.7 are not stripped off. These get encoded differently now.

This patch adds a new config option called "parseOldSigns" for people (like me) with hundreds of signs created in 1.7 that no longer have any effect in 1.8. If parseOldSigns == true, the first line of any sign starting with a recognized TrainCarts pattern ("train", "cart", "t ", ...) will be updated. This allows TrainCarts to recognize the sign, and as a bonus, when the chunk is loaded the sign is updated!

This option defaults to false.

I confess this is a hack and not particularly elegant, but this sign conversion is unfortunately necessary for backward compatibility.