### PR TITLE
Change collision logic to use many new categories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.bergerkiller.bukkit</groupId>
     <artifactId>TrainCarts</artifactId>
-    <version>1.73.1-SNAPSHOT</version>
+    <version>1.74.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>TrainCarts</name>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.bergerkiller.bukkit</groupId>
             <artifactId>BKCommonLib</artifactId>
-            <version>1.63-SNAPSHOT</version>
+            <version>1.66-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/bergerkiller/bukkit/tc/TCListener.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/TCListener.java
@@ -16,6 +16,7 @@ import com.bergerkiller.bukkit.tc.properties.CartPropertiesStore;
 import com.bergerkiller.bukkit.tc.signactions.SignAction;
 import com.bergerkiller.bukkit.tc.storage.OfflineGroupManager;
 import com.bergerkiller.bukkit.tc.utils.TrackMap;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -236,6 +237,7 @@ public class TCListener implements Listener {
         MinecartMember<?> member = MinecartMemberStore.get(event.getVehicle());
         if (member != null && member.isInteractable()) {
             CartProperties prop = member.getProperties();
+
             if (event.getEntered() instanceof Player) {
                 Player player = (Player) event.getEntered();
                 if (prop.getPlayersEnter() && (prop.isPublic() || prop.hasOwnership(player))) {
@@ -243,8 +245,11 @@ public class TCListener implements Listener {
                 } else {
                     event.setCancelled(true);
                 }
-            } else if (member.getGroup().getProperties().mobCollision != CollisionMode.ENTER) {
-                event.setCancelled(true);
+            } else {
+                CollisionMode x = member.getGroup().getProperties().getCollisionMode(event.getEntered());
+                if (x != CollisionMode.ENTER) {
+                    event.setCancelled(true);
+                }
             }
             member.onPropertiesChanged();
         }

--- a/src/main/java/com/bergerkiller/bukkit/tc/properties/CollisionConfig.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/properties/CollisionConfig.java
@@ -1,0 +1,171 @@
+package com.bergerkiller.bukkit.tc.properties;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.logging.Level;
+
+import org.bukkit.entity.Entity;
+
+import com.bergerkiller.bukkit.common.utils.EntityGroupingUtil;
+import com.bergerkiller.bukkit.common.utils.EntityGroupingUtil.EntityCategory;
+import com.bergerkiller.bukkit.tc.CollisionMode;
+import com.bergerkiller.bukkit.tc.TrainCarts;
+
+/*
+ * This enum contains entity types that a minecart could collide with.
+ * This allows the user to configure collision modes in a very granular
+ * fashion. The categories here are based on the minecraft wiki
+ * (http://minecraft.gamepedia.com/Mobs#List_of_mobs) and in
+ * com.bergerkiller.bukkit.common.utils.EntityGroupingUtil.
+ */
+
+public enum CollisionConfig {
+    /*
+     * Short Name, Plural Name, EntityCategory or method name, Legacy Mob, Display String, Default Collision Mode
+     * Legacy Mob = In versions of TrainCarts for Minecraft <= 1.7
+     */
+    PETS("pet", "pets", EntityCategory.TAMED, false, "Pets", null),
+    JOCKEYS("jockey", "jockeys", EntityCategory.JOCKEY, false, "Jockeys", null),
+    KILLER_BUNNIES("killer_bunny", "killer_bunnies", EntityCategory.KILLER_BUNNY, false, "Killer Bunnies", null),
+    NPCS("npc", "npcs", EntityCategory.NPC, false, "NPCs", null),
+    ANIMALS("animal", "animals", EntityCategory.ANIMAL, false, "Animals", null),
+    MONSTERS("monster", "monsters", EntityCategory.MONSTER, false, "Monsters", null),
+    PASSIVE_MOBS("passive", "passives", EntityCategory.PASSIVE, true, "Passive Mobs", CollisionMode.DEFAULT),
+    NEUTRAL_MOBS("neutral", "neutrals", EntityCategory.NEUTRAL, true, "Neutral Mobs", CollisionMode.DEFAULT),
+    HOSTILE_MOBS("hostile", "hostiles", EntityCategory.HOSTILE, true, "Hostile Mobs", CollisionMode.DEFAULT),
+    TAMEABLE_MOBS("tameable", "tameables", EntityCategory.TAMEABLE, true, "Tameable Mobs", CollisionMode.DEFAULT),
+    UTILITY_MOBS("utility", "utilities", EntityCategory.UTILITY, true, "Utility Mobs", CollisionMode.DEFAULT),
+    BOSS_MOBS("boss", "bosses", EntityCategory.BOSS, true, "Boss Mobs", CollisionMode.DEFAULT);
+
+    private String mobType;
+    private Method method;
+    private boolean addToConfigFile;
+    private String friendlyMobName;
+    private String pluralMobType;
+    private CollisionMode defaultCollisionMode;
+    private Set<Class<?>> entityClasses;
+
+    CollisionConfig(String mobType, String pluralMobType, EntityCategory entityCategory, boolean addToConfigFile, String friendlyMobName, CollisionMode defaultCollisionMode) {
+        this.setMobType(mobType);
+        this.setMethod(null);
+        this.setAddToConfigFile(addToConfigFile);
+        this.setFriendlyMobName(friendlyMobName);
+        this.setDefaultCollisionMode(defaultCollisionMode);
+        this.setEntityClasses(entityCategory.getEntityClasses());
+    }
+
+    public boolean isMobType(Entity entity) {
+        if (entityClasses != null && entityClasses.size() > 0) {
+            if (EntityGroupingUtil.isEntityTypeClass(entity, entityClasses)) {
+                return true;
+            }
+        }
+        if (method != null) {
+            try {
+                Object result = method.invoke(null, entity);
+                if (result == null) {
+                    TrainCarts.plugin.log(Level.WARNING, "Invoke method (" + method.getName() + ") returned null!");
+                    return false;
+                }
+                return (boolean) result;
+            } catch (Exception e) {
+                TrainCarts.plugin.log(Level.WARNING, "Method (" + method.getName() + ") threw exception: " + e.toString());
+                return false;
+            }
+        }
+        return false;
+    }
+
+    public String getMobType() {
+        return mobType;
+    }
+
+    public void setMobType(String mobType) {
+        this.mobType = mobType;
+    }
+
+    public boolean isAddToConfigFile() {
+        return addToConfigFile;
+    }
+
+    public void setAddToConfigFile(boolean addToConfigFile) {
+        this.addToConfigFile = addToConfigFile;
+    }
+
+    public static CollisionConfig findMobType(Entity entity) {
+        for (CollisionConfig collisionConfigObject : CollisionConfig.values()) {
+            if (collisionConfigObject.isMobType(entity)) {
+                return collisionConfigObject;
+            }
+        }
+        return null;
+    }
+
+    public static CollisionConfig findMobType(String entityType) {
+        for (CollisionConfig collisionConfigObject : CollisionConfig.values()) {
+            if (collisionConfigObject.getMobType().equals(entityType)) {
+                return collisionConfigObject;
+            }
+        }
+        return null;
+    }
+
+    public static CollisionConfig findMobType(String entityType, String prefix) {
+        if (prefix == null) {
+            return findMobType(entityType);
+        } else {
+            return findMobType(entityType.substring(prefix.length()));
+        }
+    }
+
+    public static CollisionConfig findMobType(String entityType, String prefix, String suffix) {
+        if (prefix == null && suffix == null) {
+            return findMobType(entityType);
+        } else if (suffix == null) {
+            return findMobType(entityType, prefix);
+        } else {
+            return findMobType(entityType.substring(0, entityType.length()-suffix.length()), prefix);
+        }
+    }
+
+    public String getFriendlyMobName() {
+        return friendlyMobName;
+    }
+
+    public void setFriendlyMobName(String friendlyMobName) {
+        this.friendlyMobName = friendlyMobName;
+    }
+
+    public String getPluralMobType() {
+        return this.pluralMobType;
+    }
+
+    public void setPluralMobType(String pluralMobType) {
+        this.pluralMobType = pluralMobType;
+    }
+
+    public CollisionMode getDefaultCollisionMode() {
+        return defaultCollisionMode;
+    }
+
+    public void setDefaultCollisionMode(CollisionMode defaultCollisionMode) {
+        this.defaultCollisionMode = defaultCollisionMode;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public void setMethod(Method method) {
+        this.method = method;
+    }
+
+    public Set<Class<?>> getEntityClasses() {
+        return entityClasses;
+    }
+
+    public void setEntityClasses(Set<Class<?>> entityClasses) {
+        this.entityClasses = entityClasses;
+    }
+
+}

--- a/src/main/java/com/bergerkiller/bukkit/tc/properties/TrainPropertiesStore.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/properties/TrainPropertiesStore.java
@@ -206,8 +206,22 @@ public class TrainPropertiesStore extends HashSet<CartProperties> {
                 node.remove("allowLinking");
                 changed = true;
             }
+            if (node.contains("collision.mobs")) {
+                for (CollisionConfig collisionConfigObject : CollisionConfig.values()) {
+                    if (collisionConfigObject.isAddToConfigFile()) {
+                        node.set("collision." + collisionConfigObject.getMobType(), node.get("collision.mobs", CollisionMode.DEFAULT).toString());
+                    }
+                }
+                node.remove("collision.mobs");
+                changed = true;
+            }
             if (node.contains("pushAway")) {
-                node.set("collision.mobs", CollisionMode.fromPushing(node.get("pushAway.mobs", false)).toString());
+                for (CollisionConfig collisionConfigObject : CollisionConfig.values()) {
+                    if (collisionConfigObject.isAddToConfigFile()) {
+                        String mobType = collisionConfigObject.getMobType();
+                        node.set("collision." + mobType, CollisionMode.fromPushing(node.get("pushAway." + mobType, false)).toString());
+                    }
+                }
                 node.set("collision.players", CollisionMode.fromPushing(node.get("pushAway.players", false)).toString());
                 node.set("collision.misc", CollisionMode.fromPushing(node.get("pushAway.misc", true)).toString());
                 node.remove("pushAway");
@@ -215,9 +229,29 @@ public class TrainPropertiesStore extends HashSet<CartProperties> {
             }
             if (node.contains("allowMobsEnter")) {
                 if (node.get("allowMobsEnter", false)) {
-                    node.set("collision.mobs", CollisionMode.ENTER.toString());
+                    for (CollisionConfig collisionConfigObject : CollisionConfig.values()) {
+                        if (collisionConfigObject.isAddToConfigFile()) {
+                            String mobType = collisionConfigObject.getMobType();
+                            node.set("collision." + mobType, CollisionMode.ENTER.toString());
+                        }
+                    }
                 }
                 node.remove("allowMobsEnter");
+                changed = true;
+            }
+            if (node.contains("mobenter") || node.contains("mobsenter")) {
+                if (node.get("mobenter", false) || node.get("mobsenter", false)) {
+                    if (node.get("allowMobsEnter", false)) {
+                        for (CollisionConfig collisionConfigObject : CollisionConfig.values()) {
+                            if (collisionConfigObject.isAddToConfigFile()) {
+                                String mobType = collisionConfigObject.getMobType();
+                                node.set("collision." + mobType, CollisionMode.ENTER.toString());
+                            }
+                        }
+                    }
+                }
+                node.remove("mobenter");
+                node.remove("mobenters");
                 changed = true;
             }
         }

--- a/src/main/java/com/bergerkiller/bukkit/tc/statements/StatementProperty.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/statements/StatementProperty.java
@@ -6,6 +6,7 @@ import com.bergerkiller.bukkit.tc.controller.MinecartGroup;
 import com.bergerkiller.bukkit.tc.controller.MinecartMember;
 import com.bergerkiller.bukkit.tc.events.SignActionEvent;
 import com.bergerkiller.bukkit.tc.properties.CartProperties;
+import com.bergerkiller.bukkit.tc.properties.CollisionConfig;
 import com.bergerkiller.bukkit.tc.properties.TrainProperties;
 
 import java.util.ArrayList;
@@ -66,7 +67,12 @@ public class StatementProperty extends Statement {
         } else if (match(playerExit, lower)) {
             return prop.getPlayersExit();
         } else if (match(mobEnter, lower)) {
-            return prop.mobCollision == CollisionMode.ENTER;
+            return prop.getAllCollisionModes().contains(CollisionMode.ENTER);
+        } else {
+            CollisionConfig result = CollisionConfig.findMobType(lower, null, "enter");
+            if (prop.getCollisionMode(result) != null) {
+                return prop.getCollisionMode(result) == CollisionMode.ENTER;
+            }
         }
 
         // Perform checks on cart properties

--- a/src/main/java/plugin.yml
+++ b/src/main/java/plugin.yml
@@ -1,7 +1,7 @@
 name: Train Carts
 main: com.bergerkiller.bukkit.tc.TrainCarts
 version: ${project.version}
-authors: [bergerkiller, lenis0012, timstans, bubba1234119, KamikazePlatypus, mg_1999, Friwi]
+authors: [bergerkiller, lenis0012, timstans, bubba1234119, KamikazePlatypus, mg_1999, Friwi, kpaulisse]
 description: Plugin that allows the use of minecart trains with adjustable settings
 depend: [BKCommonLib]
 softdepend: [MinecartManiaCore, SignLink, My Worlds]


### PR DESCRIPTION
*NOTE* This requires my corresponding updates to BKCommonLib to work correctly!!!

Enhances TrainCarts to specify different actions for these mob types:
- Categories on Minecraft wiki: passive, neutral, hostile, tameable, utility, boss
- Categories previously in BKCommonLib: animal, monster, NPC
- New categories added to BKCommonLib: pets (tamed animals), jockeys, killer bunnies

Previously there was just 1 category, "mob". Now you can specify, for example, that the train will damage hostile mobs, pick up passive mobs, and kill neutral mobs.

Also added new action types, DAMAGE and DAMAGENODROPS, which damages an entity proportional to the energy of the cart that hit it, and pushes it aside. (Faster carts do more damage and the damage amount is configurable.)

All collision categories are now in an ENUM so this should be easily extensible to add additional categories without major changes to the code.