### PR TITLE
Allow pushing of minecarts/trains

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.bergerkiller.bukkit</groupId>
     <artifactId>TrainCarts</artifactId>
-    <version>1.74-SNAPSHOT</version>
+    <version>1.75-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>TrainCarts</name>

--- a/src/main/java/com/bergerkiller/bukkit/tc/properties/TrainProperties.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/properties/TrainProperties.java
@@ -563,7 +563,7 @@ public class TrainProperties extends TrainPropertiesStore implements IProperties
             }
         } else if (entity instanceof Player) {
             GameMode playerGameMode = ((Player) entity).getGameMode();
-            if (playerGameMode == GameMode.CREATIVE || playerGameMode == GameMode.SPECTATOR) {
+            if (playerGameMode == GameMode.SPECTATOR) {
                 return CollisionMode.CANCEL;
             }
             if (TrainCarts.collisionIgnoreOwners && this.playerCollision != CollisionMode.DEFAULT) {
@@ -574,6 +574,13 @@ public class TrainProperties extends TrainPropertiesStore implements IProperties
                 }
                 if (this.hasOwnership((Player) entity)) {
                     return CollisionMode.DEFAULT;
+                }
+            }
+            // Don't kill or damage players in creative
+            if (playerGameMode == GameMode.CREATIVE) {
+                if (this.playerCollision == CollisionMode.KILL || this.playerCollision == CollisionMode.KILLNODROPS ||
+                        this.playerCollision == CollisionMode.DAMAGE || this.playerCollision == CollisionMode.DAMAGENODROPS) {
+                    return CollisionMode.PUSH;
                 }
             }
             return this.playerCollision;


### PR DESCRIPTION
Improved logic:
- Ignore (cancel) collisions with spectator mode
- Don't kill or damage players in creative - push them aside
- Determine whether player is pushing minecart or minecart is running player over. If player is pushing minecart (which is tracked as a collision), set collision mode for this interaction to default, so player can push the cart. If the minecart is running the player over, use the configured player collision mode.

Probably solves https://github.com/bergerhealer/TrainCarts/issues/13 and https://github.com/bergerhealer/TrainCarts/issues/12