### PR TITLE
Relative launcher speed

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionLauncher.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionLauncher.java
@@ -25,6 +25,10 @@ public class SignActionLauncher extends SignAction {
         // Parse the launch speed
         double velocity = ParseUtil.parseDouble(info.getLine(2), TrainCarts.launchForce);
 
+        if (info.getLine(2).startsWith("+") || info.getLine(2).startsWith("-")) {
+            velocity += info.getMember().getForce();
+        }
+
         // Parse the launch distance
         double distance = ParseUtil.parseDouble(info.getLine(1), 1.0);
 


### PR DESCRIPTION
If the speed of a launcher sign starts with + or -, it is relative.
The speed will be added to the current speed of the train.

If the train is going at 0.4 blocks/tick and the launcher speed is +0.2 blocks/tick, the train will be accelerated to 0.6 blocks/tick.

Closes #94 