### PR TITLE
Disable remote control for trains with the default name

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/controller/MinecartGroupStore.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/controller/MinecartGroupStore.java
@@ -112,7 +112,7 @@ public class MinecartGroupStore extends ArrayList<MinecartMember<?>> {
             boolean first = expression.startsWith("*");
             boolean last = expression.endsWith("*");
             for (MinecartGroup group : groups) {
-                if (group.getProperties().matchName(elements, first, last)) {
+                if (group.getProperties().isTrainRenamed() && group.getProperties().matchName(elements, first, last)) {
                     rval.add(group);
                 }
             }


### PR DESCRIPTION
This disables remote control if a train was never renamed.

This prevents users from matching all trains on the server.
This should not break anything because everyone who uses Remote Control already renames the trains.

Closes #113 