### PR TITLE
Add /train issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,23 @@
         <project.bkcversion>1.11.2-v2</project.bkcversion>
         <project.slversion>1.11.2-v2-SNAPSHOT</project.slversion>
         <project.mwversion>1.11.2-v2-SNAPSHOT</project.mwversion>
+        <project.cibuild/>
         <junit.version>4.11</junit.version>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <activation>
+                <property>
+                    <name>env.BUILD_NUMBER</name>
+                </property>
+            </activation>
+            <properties>
+                <project.cibuild>-#${env.BUILD_NUMBER}</project.cibuild>
+            </properties>
+        </profile>
+    </profiles>
 
     <repositories>
         <!-- Repo for access to CraftBukkit -->

--- a/src/main/java/com/bergerkiller/bukkit/tc/Permission.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/Permission.java
@@ -22,11 +22,11 @@ public class Permission extends PermissionEnum {
     public static final Permission COMMAND_PLAYEREXIT = new Permission("train.command.playerexit", PermissionDefault.TRUE, "The player can set if players can exit his owned carts");
     public static final Permission COMMAND_PICKUP = new Permission("train.command.pickup", PermissionDefault.TRUE, "The player can set if his owned storage carts pick up items");
     public static final Permission COMMAND_SETLINKING = new Permission("train.command.setlinking", PermissionDefault.TRUE, "The player can set if his owned trains can link to other trains");
-    public static final Permission COMMAND_KEEPCHUNKSLOADED = new Permission("train.command.keepchunksloaded", PermissionDefault.OP, "The player can if his owned trains keep nearby chunks loaded");
-    public static final Permission COMMAND_INVINCIBLE = new Permission("train.command.invincible", PermissionDefault.OP, "The player can if his owned trains make it invincible");
-    public static final Permission COMMAND_PUSHING = new Permission("train.command.pushing", PermissionDefault.TRUE, "The player can if his owned trains push away certain entities");
-    public static final Permission COMMAND_SLOWDOWN = new Permission("train.command.slowdown", PermissionDefault.TRUE, "The player can if his owned trains slow down over time");
-    public static final Permission COMMAND_SETCOLLIDE = new Permission("train.command.setcollide", PermissionDefault.TRUE, "The player can if his owned trains can collide");
+    public static final Permission COMMAND_KEEPCHUNKSLOADED = new Permission("train.command.keepchunksloaded", PermissionDefault.OP, "The player can set if his owned trains keep nearby chunks loaded");
+    public static final Permission COMMAND_INVINCIBLE = new Permission("train.command.invincible", PermissionDefault.OP, "The player can set if his owned trains are invincible");
+    public static final Permission COMMAND_PUSHING = new Permission("train.command.pushing", PermissionDefault.TRUE, "The player can set if his owned trains push away certain entities");
+    public static final Permission COMMAND_SLOWDOWN = new Permission("train.command.slowdown", PermissionDefault.TRUE, "The player can set if his owned trains slow down over time");
+    public static final Permission COMMAND_SETCOLLIDE = new Permission("train.command.setcollide", PermissionDefault.TRUE, "The player can set if his owned trains can collide");
     public static final Permission COMMAND_SETSPEEDLIMIT = new Permission("train.command.setspeedlimit", PermissionDefault.TRUE, "The player can set the maximum speed for his trains");
     public static final Permission COMMAND_SETPOWERCARTREQ = new Permission("train.command.setpoweredcartrequirement", PermissionDefault.TRUE, "The player can set if a powered minecart is needed for his train to stay alive");
     public static final Permission COMMAND_DEFAULT = new Permission("train.command.default", PermissionDefault.OP, "The player can apply default settings to his owned trains");
@@ -41,6 +41,7 @@ public class Permission extends PermissionEnum {
     public static final Permission COMMAND_TELEPORT = new Permission("train.command.teleport", PermissionDefault.OP, "Whether the player can teleport to where trains are");
     public static final Permission COMMAND_CHANGEBLOCK = new Permission("train.command.changeblock", PermissionDefault.OP, "Whether the player can alter the type of block displayed in a minecart");
     public static final Permission COMMAND_CHANGETICK = new Permission("train.command.changetick", PermissionDefault.OP, "Whether the player can alter the global update tick rate of TrainCarts (debug!)");
+    public static final Permission COMMAND_ISSUE = new Permission("train.command.issue", PermissionDefault.TRUE, "Whether the player can report problems with TrainCarts");
     public static final Permission BUILD_STATION = new Permission("train.build.station", PermissionDefault.OP, "The player can build train stations");
     public static final Permission BUILD_SPAWNER = new Permission("train.build.spawner", PermissionDefault.OP, "The player can build train spawners");
     public static final Permission SPAWNER_AUTOMATIC = new Permission("train.spawner.automatic", PermissionDefault.TRUE, "The player can build spawners which automatically create carts");

--- a/src/main/java/com/bergerkiller/bukkit/tc/commands/GlobalCommands.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/commands/GlobalCommands.java
@@ -1,6 +1,7 @@
 package com.bergerkiller.bukkit.tc.commands;
 
 import com.bergerkiller.bukkit.common.MessageBuilder;
+import com.bergerkiller.bukkit.common.internal.CommonPlugin;
 import com.bergerkiller.bukkit.common.permissions.NoPermissionException;
 import com.bergerkiller.bukkit.common.utils.StringUtil;
 import com.bergerkiller.bukkit.common.utils.WorldUtil;
@@ -22,6 +23,9 @@ import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Player;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 public class GlobalCommands {
 
@@ -221,6 +225,29 @@ public class GlobalCommands {
                     sender.sendMessage(ChatColor.GREEN + "Trains ticked " + TrainCarts.tickUpdateNow + " times");
                 }
             }
+            return true;
+        } else if (args[0].equals("issue")) {
+            Permission.COMMAND_ISSUE.handle(sender);
+            MessageBuilder builder = new MessageBuilder();
+            builder.yellow("Click here to report an issue with TrainCarts: ");
+            try {
+                String build = String.valueOf(TrainCarts.plugin.getPluginYaml().get("build"));
+                String template = "##### BkCommonLib version: " + CommonPlugin.getInstance().getVersion() +
+                        "\n##### TrainCarts version: " + TrainCarts.plugin.getVersion() +
+                        "\n##### Spigot version: " + Bukkit.getVersion() +
+                        "\n\n" +
+                        "<hr>\n" +
+                        "\n" +
+                        "#### Problem or bug:\n" +
+                        "\n" +
+                        "#### Expected behaviour:\n" +
+                        "\n" +
+                        "#### Steps to reproduce:\n";
+                builder.white("https://github.com/bergerhealer/TrainCarts/issues/new?body=" + URLEncoder.encode(template, "UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                builder.white("https://github.com/bergerhealer/TrainCarts/issues/new");
+            }
+            builder.send(sender);
             return true;
         }
         return false;

--- a/src/main/java/plugin.yml
+++ b/src/main/java/plugin.yml
@@ -1,6 +1,6 @@
 name: Train_Carts
 main: com.bergerkiller.bukkit.tc.TrainCarts
-version: ${project.version}
+version: ${project.version}${project.cibuild}
 authors: [bergerkiller, lenis0012, timstans, bubba1234119, KamikazePlatypus, mg_1999, Friwi, kpaulisse]
 description: Plugin that allows the use of minecart trains with adjustable settings
 depend: [BKCommonLib]


### PR DESCRIPTION
The command `/train issue` generates a link to create a new issue in the issue tracker.
The version fields will be filled automatically.
This also appends the Jenkins build number (if it exists) to the version: `1.12-v1-SNAPSHOT-#49`