### PR TITLE
Saved Train Modules

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/TrainCarts.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/TrainCarts.java
@@ -60,6 +60,7 @@ public class TrainCarts extends PluginBase {
     private AttachmentModelStore attachmentModels;
     private SpawnSignManager spawnSignManager;
     private SavedTrainPropertiesStore savedTrainsStore;
+    private List<SavedTrainPropertiesStore> savedTrainsModules;
     private TCMountPacketHandler mountHandler;
     private SeatAttachmentMap seatAttachmentMap;
 
@@ -313,7 +314,7 @@ public class TrainCarts extends PluginBase {
 
         //Load saved trains
         this.savedTrainsStore = new SavedTrainPropertiesStore(getDataFolder() + File.separator + "SavedTrainProperties.yml");
-
+        this.savedTrainsModules = SavedTrainPropertiesStore.loadSavedTrainsModules(getDataFolder() + File.separator + "savedTrainModules");
         //Load groups
         OfflineGroupManager.init(getDataFolder() + File.separator + "trains.groupdata");
 

--- a/src/main/java/com/bergerkiller/bukkit/tc/TrainCarts.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/TrainCarts.java
@@ -240,6 +240,11 @@ public class TrainCarts extends PluginBase {
         config.save();
     }
 
+    public void loadSavedTrains() {
+        this.savedTrainsStore = new SavedTrainPropertiesStore(getDataFolder() + File.separator + "SavedTrainProperties.yml");
+        this.savedTrainsStore.loadModules(getDataFolder() + File.separator + "savedTrainModules");
+    }
+
     @Override
     public void updateDependency(Plugin plugin, String pluginName, boolean enabled) {
         TCPortalManager.updateProviders(pluginName, plugin, enabled);
@@ -312,8 +317,7 @@ public class TrainCarts extends PluginBase {
         TicketStore.load();
 
         //Load saved trains
-        this.savedTrainsStore = new SavedTrainPropertiesStore(getDataFolder() + File.separator + "SavedTrainProperties.yml");
-        this.savedTrainsStore.loadModules(getDataFolder() + File.separator + "savedTrainModules");
+        loadSavedTrains();
 
         //Load groups
         OfflineGroupManager.init(getDataFolder() + File.separator + "trains.groupdata");

--- a/src/main/java/com/bergerkiller/bukkit/tc/TrainCarts.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/TrainCarts.java
@@ -60,7 +60,6 @@ public class TrainCarts extends PluginBase {
     private AttachmentModelStore attachmentModels;
     private SpawnSignManager spawnSignManager;
     private SavedTrainPropertiesStore savedTrainsStore;
-    private List<SavedTrainPropertiesStore> savedTrainsModules;
     private TCMountPacketHandler mountHandler;
     private SeatAttachmentMap seatAttachmentMap;
 
@@ -314,7 +313,8 @@ public class TrainCarts extends PluginBase {
 
         //Load saved trains
         this.savedTrainsStore = new SavedTrainPropertiesStore(getDataFolder() + File.separator + "SavedTrainProperties.yml");
-        this.savedTrainsModules = SavedTrainPropertiesStore.loadSavedTrainsModules(getDataFolder() + File.separator + "savedTrainModules");
+        this.savedTrainsStore.loadModules(getDataFolder() + File.separator + "savedTrainModules");
+
         //Load groups
         OfflineGroupManager.init(getDataFolder() + File.separator + "trains.groupdata");
 

--- a/src/main/java/com/bergerkiller/bukkit/tc/commands/GlobalCommands.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/commands/GlobalCommands.java
@@ -120,7 +120,9 @@ public class GlobalCommands {
             return true;
         } else if (args[0].equals("reloadsavedtrains")) {
             Permission.COMMAND_RELOAD.handle(sender);
+            TrainCarts.plugin.save(false);
             TrainCarts.plugin.loadSavedTrains();
+            sender.sendMessage(ChatColor.YELLOW + "Reloaded saved trains and modules");
             return true;
         } else if (args[0].equals("saveall")) {
             Permission.COMMAND_SAVEALL.handle(sender);

--- a/src/main/java/com/bergerkiller/bukkit/tc/commands/GlobalCommands.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/commands/GlobalCommands.java
@@ -118,6 +118,9 @@ public class GlobalCommands {
             TrainCarts.plugin.loadConfig();
             sender.sendMessage(ChatColor.YELLOW + "Configuration has been reloaded.");
             return true;
+        } else if (args[0].equals("reloadsavedtrains")) {
+            Permission.COMMAND_RELOAD.handle(sender);
+            TrainCarts.plugin.loadSavedTrains();
         } else if (args[0].equals("saveall")) {
             Permission.COMMAND_SAVEALL.handle(sender);
             TrainCarts.plugin.save(false);

--- a/src/main/java/com/bergerkiller/bukkit/tc/commands/GlobalCommands.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/commands/GlobalCommands.java
@@ -121,6 +121,7 @@ public class GlobalCommands {
         } else if (args[0].equals("reloadsavedtrains")) {
             Permission.COMMAND_RELOAD.handle(sender);
             TrainCarts.plugin.loadSavedTrains();
+            return true;
         } else if (args[0].equals("saveall")) {
             Permission.COMMAND_SAVEALL.handle(sender);
             TrainCarts.plugin.save(false);

--- a/src/main/java/com/bergerkiller/bukkit/tc/commands/TrainCommands.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/commands/TrainCommands.java
@@ -477,7 +477,7 @@ public class TrainCommands {
                     String name = args[0];
                     boolean wasContained = TrainCarts.plugin.getSavedTrains().getConfig(name) != null;
                     try {
-                        TrainCarts.plugin.getSavedTrains().save(group, name);
+                        TrainCarts.plugin.getSavedTrains().save(group, name, args[1]);
                         if (wasContained) {
                             p.sendMessage(ChatColor.GREEN + "The train was saved as " + name + ", a previous train was overwritten");
                         } else {

--- a/src/main/java/com/bergerkiller/bukkit/tc/commands/TrainCommands.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/commands/TrainCommands.java
@@ -477,11 +477,17 @@ public class TrainCommands {
                     String name = args[0];
                     boolean wasContained = TrainCarts.plugin.getSavedTrains().getConfig(name) != null;
                     try {
-                        TrainCarts.plugin.getSavedTrains().save(group, name, args[1]);
+                        String module = null;
+                        String moduleString = "";
+                        if (args.length > 1) {
+                            module = args[1];
+                            moduleString = " in module " + module;
+                        }
+                        TrainCarts.plugin.getSavedTrains().save(group, name, module);
                         if (wasContained) {
-                            p.sendMessage(ChatColor.GREEN + "The train was saved as " + name + ", a previous train was overwritten");
+                            p.sendMessage(ChatColor.GREEN + "The train was saved as " + name + moduleString + ", a previous train was overwritten");
                         } else {
-                            p.sendMessage(ChatColor.GREEN + "The train was saved as " + name);
+                            p.sendMessage(ChatColor.GREEN + "The train was saved as " + name + moduleString);
                         }
                     } catch (IllegalNameException ex) {
                         p.sendMessage(ChatColor.RED + "The train could not be saved under this name: " + ex.getMessage());

--- a/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
@@ -29,6 +29,7 @@ import com.bergerkiller.bukkit.tc.exception.IllegalNameException;
  */
 public class SavedTrainPropertiesStore {
     private final FileConfiguration savedTrainsConfig;
+    private String modulesDirectory = "";
     private final List<String> names = new ArrayList<String>();
     private Map<String, SavedTrainPropertiesStore> modules = new HashMap<String, SavedTrainPropertiesStore>();;
     private boolean changed = false;
@@ -50,17 +51,22 @@ public class SavedTrainPropertiesStore {
 
     public void loadModules(String directory) {
         if (this.allowModules) {
+            this.modulesDirectory = directory;
             File dir = new File(directory);
             if (!dir.exists()) {
                 dir.mkdir();
             }
             for (File file : StreamUtil.listFiles(dir)) {
                 String name = file.getName();
-                modules.put(name, new SavedTrainPropertiesStore(directory + File.separator + name, false));
+                createModule(name);
             }
         } else {
             throw new UnsupportedOperationException("This store is not authorized to load modules");
         }
+    }
+
+    private void createModule(String name) {
+        modules.put(name, new SavedTrainPropertiesStore(modulesDirectory + File.separator + name, false));
     }
 
     public void save(boolean autosave) {
@@ -89,9 +95,9 @@ public class SavedTrainPropertiesStore {
         if (Character.isDigit(name.charAt(0))) {
             throw new IllegalNameException("Name starts with a digit");
         }
-        if (module != null) {
+        if (module != null && this.allowModules) {
             if (!this.modules.containsKey(module)) {
-                throw new IllegalNameException("There is no loaded module by that name");
+                createModule(module);
             }
             this.modules.get(module).save(group, name, module);
             return;

--- a/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
@@ -1,10 +1,12 @@
 package com.bergerkiller.bukkit.tc.properties;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.logging.Level;
 
+import com.bergerkiller.bukkit.common.utils.StreamUtil;
 import org.bukkit.util.Vector;
 
 import com.bergerkiller.bukkit.common.config.ConfigurationNode;
@@ -300,5 +302,13 @@ public class SavedTrainPropertiesStore {
         positionNode.set("rotX", MathUtil.round(rot.getX(), 6));
         positionNode.set("rotY", MathUtil.round(rot.getY(), 6));
         positionNode.set("rotZ", MathUtil.round(rot.getZ(), 6));
+    }
+
+    public static List<SavedTrainPropertiesStore> loadSavedTrainsModules(String directory) {
+        List<SavedTrainPropertiesStore> modules = new ArrayList<>();
+        for (File file : StreamUtil.listFiles(new File(directory))) {
+            modules.add(new SavedTrainPropertiesStore(directory + File.separator + file.getName()));
+        }
+        return modules;
     }
 }

--- a/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
@@ -9,6 +9,7 @@ import java.util.ListIterator;
 import java.util.logging.Level;
 
 import com.bergerkiller.bukkit.common.utils.StreamUtil;
+import org.bukkit.util.FileUtil;
 import org.bukkit.util.Vector;
 
 import com.bergerkiller.bukkit.common.config.ConfigurationNode;
@@ -65,8 +66,17 @@ public class SavedTrainPropertiesStore {
         }
     }
 
-    private void createModule(String name) {
-        modules.put(name, new SavedTrainPropertiesStore(modulesDirectory + File.separator + name, false));
+    /**
+     * Create a module from a filename. If it does not exist, it will be created.
+     * @param fileName The filename of the desired module, in format `moduleName.yml`
+     */
+    private void createModule(String fileName) {
+        String name = fileName;
+        if (fileName.indexOf(".") > 0) {
+            name = fileName.substring(0, fileName.lastIndexOf("."));
+        }
+
+        modules.put(name, new SavedTrainPropertiesStore(modulesDirectory + File.separator + fileName, false));
     }
 
     public void save(boolean autosave) {
@@ -97,7 +107,7 @@ public class SavedTrainPropertiesStore {
         }
         if (module != null && this.allowModules) {
             if (!this.modules.containsKey(module)) {
-                createModule(module);
+                createModule(module + ".yml");
             }
             this.modules.get(module).save(group, name, module);
             return;

--- a/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
@@ -1,7 +1,11 @@
 package com.bergerkiller.bukkit.tc.properties;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ListIterator;
 import java.util.logging.Level;
 
 import com.bergerkiller.bukkit.common.utils.StreamUtil;

--- a/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
@@ -50,7 +50,11 @@ public class SavedTrainPropertiesStore {
 
     public void loadModules(String directory) {
         if (this.allowModules) {
-            for (File file : StreamUtil.listFiles(new File(directory))) {
+            File dir = new File(directory);
+            if (!dir.exists()) {
+                dir.mkdir();
+            }
+            for (File file : StreamUtil.listFiles(dir)) {
                 String name = file.getName();
                 modules.put(name, new SavedTrainPropertiesStore(directory + File.separator + name, false));
             }

--- a/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/properties/SavedTrainPropertiesStore.java
@@ -1,9 +1,7 @@
 package com.bergerkiller.bukkit.tc.properties;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ListIterator;
+import java.util.*;
 import java.util.logging.Level;
 
 import com.bergerkiller.bukkit.common.utils.StreamUtil;
@@ -28,40 +26,40 @@ import com.bergerkiller.bukkit.tc.exception.IllegalNameException;
 public class SavedTrainPropertiesStore {
     private final FileConfiguration savedTrainsConfig;
     private final List<String> names = new ArrayList<String>();
+    private Map<String, SavedTrainPropertiesStore> modules = new HashMap<String, SavedTrainPropertiesStore>();;
     private boolean changed = false;
+    private boolean allowModules = true;
 
     public SavedTrainPropertiesStore(String filename) {
         this.savedTrainsConfig = new FileConfiguration(filename);
         this.savedTrainsConfig.load();
         this.names.addAll(this.savedTrainsConfig.getKeys());
 
-        // Rename trains starting with a number, as this breaks things
-        ListIterator<String> iter = this.names.listIterator();
-        while (iter.hasNext()) {
-            String name = iter.next();
-            if (!this.savedTrainsConfig.isNode(name)) {
-                iter.remove();
-                continue;
-            }
-            if (!name.isEmpty() && !Character.isDigit(name.charAt(0))) {
-                continue;
-            }
-
-            String new_name = "t" + name;
-            for (int i = 1; names.contains(new_name); i++) {
-                new_name = "t" + name + i;
-            }
-
-            TrainCarts.plugin.log(Level.WARNING, "Train name '"  + name + "' starts with a digit, renamed to " + new_name);
-            iter.set(new_name);
-            this.savedTrainsConfig.set(new_name, this.savedTrainsConfig.getNode(name).clone());
-            this.savedTrainsConfig.remove(name);
-            this.changed = true;
-        }
+        renameTrainsBeginningWithDigits();
 
     }
 
+    public SavedTrainPropertiesStore(String filename, boolean allowModules) {
+        this(filename);
+        this.allowModules = allowModules;
+    }
+
+    public void loadModules(String directory) {
+        if (this.allowModules) {
+            for (File file : StreamUtil.listFiles(new File(directory))) {
+                String name = file.getName();
+                modules.put(name, new SavedTrainPropertiesStore(directory + File.separator + name, false));
+            }
+        } else {
+            throw new UnsupportedOperationException("This store is not authorized to load modules");
+        }
+    }
+
     public void save(boolean autosave) {
+        for (SavedTrainPropertiesStore module : this.modules.values()) {
+            module.save(autosave);
+        }
+
         if (autosave && !this.changed) {
             return;
         }
@@ -74,13 +72,21 @@ public class SavedTrainPropertiesStore {
      * 
      * @param group to save
      * @param name to save as
+     * @param module to save in. null for the default store.
      */
-    public void save(MinecartGroup group, String name) throws IllegalNameException {
+    public void save(MinecartGroup group, String name, String module) throws IllegalNameException {
         if (name == null || name.isEmpty()) {
             throw new IllegalNameException("Name is empty");
         }
         if (Character.isDigit(name.charAt(0))) {
             throw new IllegalNameException("Name starts with a digit");
+        }
+        if (module != null) {
+            if (!this.modules.containsKey(module)) {
+                throw new IllegalNameException("There is no loaded module by that name");
+            }
+            this.modules.get(module).save(group, name, module);
+            return;
         }
 
         this.changed = true;
@@ -120,25 +126,50 @@ public class SavedTrainPropertiesStore {
      */
     public ConfigurationNode getConfig(String name) {
         if (!this.savedTrainsConfig.isNode(name)) {
+            for (SavedTrainPropertiesStore module : this.modules.values()) {
+                ConfigurationNode config = module.getConfig(name);
+                if (config != null) {
+                    return config;
+                }
+            }
             return null;
         }
         return this.savedTrainsConfig.getNode(name);
     }
 
     /**
-     * Attempts to find a String token that starts with the name of a saved train
+     * Attempts to find a String token that starts with the name of a saved train. First searches
+     * modules, then searches the default store.
      * 
      * @param text to find a name in
      * @return name found, null if none found
      */
     public String findName(String text) {
         String foundName = null;
+
+        for (SavedTrainPropertiesStore module : this.modules.values()) {
+            String name = module.findName(text);
+            if (name != null) {
+                foundName = name;
+            }
+        }
+
+
         for (String name : this.names) {
             if (text.startsWith(name) && (foundName == null || name.length() > foundName.length())) {
                 foundName = name;
             }
         }
+
         return foundName;
+    }
+
+    /**
+     * Get a list of all saved trains in this store (not including modules)
+     * @return A List of the names of all saved trains' in this store
+     */
+    public List<String> getNames() {
+        return this.names;
     }
 
     /**
@@ -154,6 +185,32 @@ public class SavedTrainPropertiesStore {
                     upgradeSavedTrains(new Matrix4x4(), new Matrix4x4(), cart.getNode("model"), undo);
                 }
             }
+        }
+    }
+
+    private void renameTrainsBeginningWithDigits() {
+        // Rename trains starting with a number, as this breaks things
+        ListIterator<String> iter = this.names.listIterator();
+        while (iter.hasNext()) {
+            String name = iter.next();
+            if (!this.savedTrainsConfig.isNode(name)) {
+                iter.remove();
+                continue;
+            }
+            if (!name.isEmpty() && !Character.isDigit(name.charAt(0))) {
+                continue;
+            }
+
+            String new_name = "t" + name;
+            for (int i = 1; names.contains(new_name); i++) {
+                new_name = "t" + name + i;
+            }
+
+            TrainCarts.plugin.log(Level.WARNING, "Train name '"  + name + "' starts with a digit, renamed to " + new_name);
+            iter.set(new_name);
+            this.savedTrainsConfig.set(new_name, this.savedTrainsConfig.getNode(name).clone());
+            this.savedTrainsConfig.remove(name);
+            this.changed = true;
         }
     }
 
@@ -293,6 +350,8 @@ public class SavedTrainPropertiesStore {
         return transform;
     }
 
+
+
     private static void setAttTransform(ConfigurationNode positionNode, Matrix4x4 transform) {
         Vector pos = transform.toVector();
         Vector rot = transform.getYawPitchRoll();
@@ -304,7 +363,7 @@ public class SavedTrainPropertiesStore {
         positionNode.set("rotZ", MathUtil.round(rot.getZ(), 6));
     }
 
-    public static List<SavedTrainPropertiesStore> loadSavedTrainsModules(String directory) {
+    private static List<SavedTrainPropertiesStore> loadSavedTrainsModules(String directory) {
         List<SavedTrainPropertiesStore> modules = new ArrayList<>();
         for (File file : StreamUtil.listFiles(new File(directory))) {
             modules.add(new SavedTrainPropertiesStore(directory + File.separator + file.getName()));


### PR DESCRIPTION
Building upon the popular new feature to save trains created with the attachment editor to `savedTrainProperties.yml`, I propose a system I call `savedTrainModules`, a paradigm for managing multiple hot-reloadable `SavedTrainPropertiesStore`s. This allows for saved trains to be easily shared across servers (useful for those managing multi-server networks) and easily edited in text editors, as well as easily compartmentalizing saved trains into logical collections, or modules.

### Usage

On startup, a new folder is created in the plugin's data folder, `savedTrainModules`. To save a train to this folder instead of the default `savedTrainProperties.yml`, run the command `/train save <name> <module>`. This will save your selected train to `savedTrainModules/<module>.yml` (and it will create the module if it does not exist). If you wish to reload modules from the disk (in the case of editing or adding additional modules), run `/train reloadsavedtrains`. 

There is no need to specify the module name when spawning a saved train, however there is currently no build in way to deal with name collision--when locating a saved train, TrainCarts will search each loaded module in an arbitrary order, before searching `savedTrainProperties.yml`. 
_This might be a good condition to address in the future_


### Implementation

This was accomplished by giving a `SavedTrainPropertiesStore` its own map of module names to `SavedTrainPropertiesStore`s (`Map<String, SavedTrainPropertiesStore>`). Loaded modules are not authorized to load their own modules.

I did not implement `upgradeSavedTrains` to upgrade the trains in loaded modules, so it's best to only use this feature with trains created on `1.12.2-v3` and later.