### PR TITLE
Added proper direction parsing to remote controlled launching

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionLauncher.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionLauncher.java
@@ -37,15 +37,13 @@ public class SignActionLauncher extends SignAction {
         LauncherConfig launchConfig = LauncherConfig.parse(launchConfigStr);
 
         if (info.isRCSign()) {
-            boolean reverse = Direction.parse(info.getLine(3)) == Direction.BACKWARD;
 
+            Direction direction = Direction.parse(info.getLine(3));
             // Launch all groups
             for (MinecartGroup group : info.getRCTrainGroups()) {
-                if (reverse) {
-                    group.reverse();
-                }
+                BlockFace directionFace = direction.getDirection(group.head().getDirection());
                 group.getActions().clear();
-                group.head().getActions().addActionLaunch(launchConfig, velocity);
+                group.head().getActions().addActionLaunch(directionFace, launchConfig, velocity);
             }
         } else if (info.hasRailedMember()) {
             // Parse the direction to launch into


### PR DESCRIPTION
Fixed a bug where remote controlled launcher signs only cared about forwards and backwards launching--it now supports all directions