### PR TITLE
Fixed annouce sign to announce to all passengers

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionAnnounce.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionAnnounce.java
@@ -20,9 +20,7 @@ public class SignActionAnnounce extends SignAction {
     }
 
     public static void sendMessage(SignActionEvent info, MinecartMember<?> member) {
-        if (member.getEntity().hasPlayerPassenger()) {
-            TrainCarts.sendMessage(member.getEntity().getPlayerPassenger(), getMessage(info));
-        }
+        member.getEntity().getPlayerPassengers().forEach(player -> TrainCarts.sendMessage(player, getMessage(info)));
     }
 
     public static String getMessage(SignActionEvent info) {


### PR DESCRIPTION
Previously, the announce sign would pick one player arbitrarily inside of each member to announce to. I've fixed it so that it targets all players returned by `member.getEntity().getPlayerPassengers()`