### PR TITLE
Centered appearance menu tabView (shifted x coord)

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/attachments/ui/menus/AppearanceMenu.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/attachments/ui/menus/AppearanceMenu.java
@@ -39,7 +39,7 @@ public class AppearanceMenu extends MapWidgetMenu implements ItemDropTarget {
             type.createAppearanceTab(this.tabView.addTab(), this.attachment);
         }
 
-        tabView.setPosition(7, 16);
+        tabView.setPosition(9, 16);
         this.addWidget(tabView);
 
         // This widget is always visible: type selector


### PR DESCRIPTION
If you look closely, you'll notice that the attachment editor menu has been slightly offset to the left this whole time! This PR shifts it two pixels to the right to center it.

Look very closely at this image, and notice how it's slightly closer to the left side than it is to the right! We simply can't live like this anymore.
![image](https://user-images.githubusercontent.com/5344055/76012224-f2a97380-5ee3-11ea-997b-abb16ccb3978.png)
