### PR TITLE
Add SmoothCoasters support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
             <version>${project.bkcversion}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>me.m56738</groupId>
+            <artifactId>SmoothCoastersAPI</artifactId>
+            <version>1.0.1</version>
+        </dependency>
 
         <dependency>
             <groupId>com.googlecode.openpojo</groupId>
@@ -171,6 +176,35 @@
 
         <!-- Plugins -->
         <plugins>
+
+            <!-- Shade plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.3</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <relocations>
+                        <relocation>
+                            <pattern>me.m56738</pattern>
+                            <shadedPattern>com.bergerkiller.bukkit.tc.dep.me.m56738</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <artifactSet>
+                        <includes>
+                            <include>me.m56738</include>
+                        </includes>
+                    </artifactSet>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
             <!-- Copy artifacts to non-versioned jar name -->
             <plugin>

--- a/src/main/java/com/bergerkiller/bukkit/tc/TrainCarts.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/TrainCarts.java
@@ -41,6 +41,7 @@ import com.bergerkiller.bukkit.tc.storage.OfflineGroupManager;
 import com.bergerkiller.bukkit.tc.tickets.TicketStore;
 import com.bergerkiller.mountiplex.conversion.Conversion;
 
+import me.m56738.smoothcoasters.api.SmoothCoastersAPI;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
@@ -79,6 +80,7 @@ public class TrainCarts extends PluginBase {
     private PathProvider pathProvider;
     private RouteManager routeManager;
     private Economy econ = null;
+    private SmoothCoastersAPI smoothCoastersAPI;
 
     /**
      * Gets a helper class for assigning (fake) entities to teams to change their glowing effect
@@ -153,6 +155,10 @@ public class TrainCarts extends PluginBase {
      */
     public Economy getEconomy() {
         return econ;
+    }
+
+    public SmoothCoastersAPI getSmoothCoastersAPI() {
+        return smoothCoastersAPI;
     }
 
     public static boolean canBreak(Material type) {
@@ -387,6 +393,9 @@ public class TrainCarts extends PluginBase {
         this.routeManager = new RouteManager(getDataFolder() + File.separator + "routes.yml");
         this.routeManager.load();
 
+        //Initialize SmoothCoastersAPI
+        this.smoothCoastersAPI = new SmoothCoastersAPI(this);
+
         //Initialize seat attachment map
         this.seatAttachmentMap = new SeatAttachmentMap();
         this.register((PacketListener) this.seatAttachmentMap, SeatAttachmentMap.LISTENED_TYPES);
@@ -526,8 +535,10 @@ public class TrainCarts extends PluginBase {
         //Unregister listeners
         this.unregister(packetListener);
         this.unregister(interactionPacketListener);
+        smoothCoastersAPI.unregister();
         packetListener = null;
         interactionPacketListener = null;
+        smoothCoastersAPI = null;
 
         //Stop tasks
         Task.stop(signtask);

--- a/src/main/java/com/bergerkiller/bukkit/tc/attachments/control/seat/FirstPersonDefault.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/attachments/control/seat/FirstPersonDefault.java
@@ -5,8 +5,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.bergerkiller.bukkit.common.Common;
+import com.bergerkiller.bukkit.common.math.Quaternion;
 import com.bergerkiller.bukkit.common.utils.PacketUtil;
 import com.bergerkiller.bukkit.common.utils.PlayerUtil;
+import com.bergerkiller.bukkit.tc.TrainCarts;
 import com.bergerkiller.bukkit.tc.attachments.VirtualEntity;
 import com.bergerkiller.bukkit.tc.attachments.VirtualEntity.SyncMode;
 import com.bergerkiller.bukkit.tc.attachments.control.CartAttachmentSeat;
@@ -19,6 +21,8 @@ import com.bergerkiller.generated.net.minecraft.server.PacketPlayOutUpdateAttrib
  */
 public class FirstPersonDefault {
     private final CartAttachmentSeat seat;
+    private Player _player;
+    private boolean _useSmoothCoasters = false;
     private boolean _useVirtualCamera = false;
     private VirtualEntity _fakeCameraMount = null;
 
@@ -27,6 +31,20 @@ public class FirstPersonDefault {
     }
 
     public void makeVisible(Player viewer) {
+        _player = viewer;
+
+        if (this.useSmoothCoasters()) {
+            Quaternion rotation = seat.getTransform().getRotation();
+            TrainCarts.plugin.getSmoothCoastersAPI().setRotation(
+                    viewer,
+                    (float) rotation.getX(),
+                    (float) rotation.getY(),
+                    (float) rotation.getZ(),
+                    (float) rotation.getW(),
+                    (byte) 0 // Set instantly
+            );
+        }
+
         if (this.useVirtualCamera()) {
             if (this._fakeCameraMount == null) {
                 this._fakeCameraMount = new VirtualEntity(seat.getManager());
@@ -57,6 +75,11 @@ public class FirstPersonDefault {
     }
 
     public void makeHidden(Player viewer) {
+        if (TrainCarts.plugin.isEnabled()) {
+            // Cannot send plugin messages while the plugin is being disabled
+            TrainCarts.plugin.getSmoothCoastersAPI().resetRotation(viewer);
+        }
+
         if (this.useVirtualCamera() && this._fakeCameraMount != null) {
             PlayerUtil.getVehicleMountController(viewer).unmount(this._fakeCameraMount.getEntityId(), viewer.getEntityId());
             this._fakeCameraMount.destroy(viewer);
@@ -71,10 +94,30 @@ public class FirstPersonDefault {
     }
 
     public void onMove(boolean absolute) {
+        if (this.useSmoothCoasters()) {
+            Quaternion rotation = seat.getTransform().getRotation();
+            TrainCarts.plugin.getSmoothCoastersAPI().setRotation(
+                    _player,
+                    (float) rotation.getX(),
+                    (float) rotation.getY(),
+                    (float) rotation.getZ(),
+                    (float) rotation.getW(),
+                    (byte) 3 // TODO 5 for minecarts
+            );
+        }
+
         if (this._fakeCameraMount != null && this.useVirtualCamera()) {
             this._fakeCameraMount.updatePosition(seat.getTransform());
             this._fakeCameraMount.syncPosition(absolute);
         }
+    }
+
+    public boolean useSmoothCoasters() {
+        return _useSmoothCoasters;
+    }
+
+    public void setUseSmoothCoasters(boolean use) {
+        this._useSmoothCoasters = use;
     }
 
     /**


### PR DESCRIPTION
Seats use [SmoothCoasters](https://github.com/56738/SmoothCoasters) to control the player camera rotation if the mod is installed on the client and the Lock Rotation seat property is enabled.

[Installation](https://github.com/56738/SmoothCoasters/wiki/Installation)