### PR TITLE
Use ISAIR Util method.

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/TCListener.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/TCListener.java
@@ -630,7 +630,7 @@ public class TCListener implements Listener {
             // If the block below is air or rail, and above is a solid
             Block below = placedBlock.getRelative(BlockFace.DOWN);
             Block above = placedBlock.getRelative(BlockFace.UP);
-            if ((below.getType() == Material.AIR || Util.ISVERTRAIL.get(below)) && BlockUtil.isSuffocating(above)) {
+            if ((Util.ISAIR.get(below) || Util.ISVERTRAIL.get(below)) && BlockUtil.isSuffocating(above)) {
 
                 // Custom placement of an upside-down normal rail
                 BlockPlaceEvent placeEvent = new BlockPlaceEvent(placedBlock, placedBlock.getState(),


### PR DESCRIPTION
**This PR should NOT be merged before https://github.com/bergerhealer/BKCommonLib/pull/100 was, as it depends on a new method added in that PR!**

This replaces the `below.getType() == Material.AIR` with `Util.ISAIR.get(below)` since 1.13 introduced `CAVE_AIR` and `VOID_AIR`, making the old check not work for 2 third of all possible checks.

Until this PR is merged would an alternative be to just replace the air blocks using WorldEdit and `//set air`