### PR TITLE
Fix upside-down rails on 1.13+

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/TCListener.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/TCListener.java
@@ -606,7 +606,7 @@ public class TCListener implements Listener {
         }
 
         Block placedBlock = event.getClickedBlock().getRelative(event.getBlockFace());
-        if (placedBlock.getType() != Material.AIR) {
+        if (!MaterialUtil.ISAIR.get(placedBlock)) {
             return;
         }
 


### PR DESCRIPTION
Changes `placedBlock.getType() != Material.AIR` to `!MaterialUtil.ISAIR.get(placedBlock)` since 1.13 added new Air types for caves and the void, which made the old check unreliable.