### PR TITLE
Fix ModelData property name not matching tooltip display

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/attachments/ui/item/CustomModelDataSelector.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/attachments/ui/item/CustomModelDataSelector.java
@@ -191,7 +191,7 @@ public abstract class CustomModelDataSelector extends MapWidget implements SetVa
 
     @Override
     public String getAcceptedPropertyName() {
-        return "Custom Model Name";
+        return "Custom Model Data";
     }
 
     @Override


### PR DESCRIPTION
Fixes `/train menu set value` output as shown below
![image](https://user-images.githubusercontent.com/26726381/126269390-4b0b46ce-0278-4c6a-ba06-c3cf3cea633a.png)
![image](https://user-images.githubusercontent.com/26726381/126269441-44743650-a8cf-4f78-9497-889747c66e88.png)
