### PR TITLE
Change HTTP repositories to HTTPS counterparts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- Repo for access to Multiverse API -->
         <repository>
             <id>onarandombox</id>
-            <url>http://repo.onarandombox.com/content/repositories/multiverse/</url>
+            <url>https://repo.onarandombox.com/content/repositories/multiverse/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Maven 3.8.1+ refuses to connect to HTTP repositories. This PR changes all HTTP to HTTPS, or uses alternative repository.
For reference, see: https://nvd.nist.gov/vuln/detail/CVE-2021-26291