### PR TITLE
Added Event: MissingPathConnectionEvent

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/events/MissingPathConnectionEvent.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/events/MissingPathConnectionEvent.java
@@ -1,0 +1,40 @@
+package com.bergerkiller.bukkit.tc.events;
+
+import com.bergerkiller.bukkit.tc.controller.MinecartGroup;
+import com.bergerkiller.bukkit.tc.pathfinding.PathNode;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This event fires if a destination couldn't be reached when a train is passing a switcher-sign
+ */
+public class MissingPathConnectionEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    protected final PathNode node;
+    private MinecartGroup group;
+    private final String destination;
+
+    public MissingPathConnectionEvent(PathNode node, MinecartGroup group, String destination) {
+        this.node = node;
+        this.group = group;
+        this.destination = destination;
+    }
+
+    public PathNode getPathNode() {
+        return this.node;
+    }
+    public MinecartGroup getGroup() { return group; }
+    public String getDestination() { return destination; }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/com/bergerkiller/bukkit/tc/events/MissingPathConnectionEvent.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/events/MissingPathConnectionEvent.java
@@ -26,9 +26,7 @@ public class MissingPathConnectionEvent extends Event {
     }
 
     public RailPiece getRail() { return rail; }
-    public PathNode getPathNode() {
-        return this.node;
-    }
+    public PathNode getPathNode() { return this.node; }
     public MinecartGroup getGroup() { return group; }
     public String getDestination() { return destination; }
 

--- a/src/main/java/com/bergerkiller/bukkit/tc/events/MissingPathConnectionEvent.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/events/MissingPathConnectionEvent.java
@@ -26,7 +26,7 @@ public class MissingPathConnectionEvent extends Event {
     }
 
     public RailPiece getRail() { return rail; }
-    public PathNode getPathNode() { return this.node; }
+    public PathNode getPathNode() { return node; }
     public MinecartGroup getGroup() { return group; }
     public String getDestination() { return destination; }
 

--- a/src/main/java/com/bergerkiller/bukkit/tc/events/MissingPathConnectionEvent.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/events/MissingPathConnectionEvent.java
@@ -1,6 +1,7 @@
 package com.bergerkiller.bukkit.tc.events;
 
 import com.bergerkiller.bukkit.tc.controller.MinecartGroup;
+import com.bergerkiller.bukkit.tc.controller.components.RailPiece;
 import com.bergerkiller.bukkit.tc.pathfinding.PathNode;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -12,16 +13,19 @@ import org.jetbrains.annotations.NotNull;
 public class MissingPathConnectionEvent extends Event {
     private static final HandlerList HANDLERS = new HandlerList();
 
-    protected final PathNode node;
-    private MinecartGroup group;
+    private final RailPiece rail;
+    private final PathNode node;
+    private final MinecartGroup group;
     private final String destination;
 
-    public MissingPathConnectionEvent(PathNode node, MinecartGroup group, String destination) {
+    public MissingPathConnectionEvent(RailPiece rail, PathNode node, MinecartGroup group, String destination) {
+        this.rail = rail;
         this.node = node;
         this.group = group;
         this.destination = destination;
     }
 
+    public RailPiece getRail() { return rail; }
     public PathNode getPathNode() {
         return this.node;
     }

--- a/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionSwitcher.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionSwitcher.java
@@ -266,7 +266,7 @@ public class SignActionSwitcher extends SignAction {
                             }
                         } else {
                             // Call MissingPathConnectionEvent
-                            CommonUtil.callEvent(new MissingPathConnectionEvent(node, info.getGroup(), destination));
+                            CommonUtil.callEvent(new MissingPathConnectionEvent(info.getRailPiece(), node, info.getGroup(), destination));
                             Localization.PATHING_FAILED.broadcast(info.getGroup(), destination);
                         }
                     }

--- a/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionSwitcher.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/signactions/SignActionSwitcher.java
@@ -1,6 +1,7 @@
 package com.bergerkiller.bukkit.tc.signactions;
 
 import com.bergerkiller.bukkit.common.collections.BlockMap;
+import com.bergerkiller.bukkit.common.utils.CommonUtil;
 import com.bergerkiller.bukkit.common.utils.LogicUtil;
 import com.bergerkiller.bukkit.tc.DirectionStatement;
 import com.bergerkiller.bukkit.tc.Localization;
@@ -11,6 +12,7 @@ import com.bergerkiller.bukkit.tc.actions.GroupActionWaitPathFinding;
 import com.bergerkiller.bukkit.tc.cache.RailMemberCache;
 import com.bergerkiller.bukkit.tc.controller.MinecartGroup;
 import com.bergerkiller.bukkit.tc.controller.MinecartMember;
+import com.bergerkiller.bukkit.tc.events.MissingPathConnectionEvent;
 import com.bergerkiller.bukkit.tc.events.SignActionEvent;
 import com.bergerkiller.bukkit.tc.events.SignChangeActionEvent;
 import com.bergerkiller.bukkit.tc.pathfinding.PathConnection;
@@ -263,6 +265,8 @@ public class SignActionSwitcher extends SignAction {
                                 info.setRailsTo(conn.junctionName);
                             }
                         } else {
+                            // Call MissingPathConnectionEvent
+                            CommonUtil.callEvent(new MissingPathConnectionEvent(node, info.getGroup(), destination));
                             Localization.PATHING_FAILED.broadcast(info.getGroup(), destination);
                         }
                     }


### PR DESCRIPTION
This Event fires if a train reaches a switcher-sign with a set destination which couldn't be reached.
It exposes the involved MinecartGroup, PathNode and destination.