### PR TITLE
Make SmoothCoasters rotation mode configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>me.m56738</groupId>
             <artifactId>SmoothCoastersAPI</artifactId>
-            <version>1.1</version>
+            <version>1.6</version>
         </dependency>
 
         <!-- Cloud command framework -->

--- a/src/main/java/com/bergerkiller/bukkit/tc/TCConfig.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/TCConfig.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import me.m56738.smoothcoasters.api.RotationMode;
 import org.bukkit.Material;
 
 import static com.bergerkiller.bukkit.common.utils.MaterialUtil.getMaterial;
@@ -110,6 +111,7 @@ public class TCConfig {
     public static MapResourcePack resourcePack = MapResourcePack.SERVER;
     public static Map<String, Animation> defaultAnimations = new HashMap<>();
     public static Hastebin hastebin = null;
+    public static RotationMode smoothCoastersRotationMode;
 
     public static void load(FileConfiguration config) {
         config.setHeader("This is the configuration file of TrainCarts");
@@ -562,6 +564,11 @@ public class TCConfig {
         } else {
             attachmentTransformParallelism = config.get("attachmentTransformParallelism", -1);
         }
+
+        config.setHeader("smoothCoastersRotationMode", "\nThe camera rotation mode to use for SmoothCoasters");
+        config.addHeader("smoothCoastersRotationMode", "PLAYER: Rotate the whole player");
+        config.addHeader("smoothCoastersRotationMode", "CAMERA: Rotate the camera without affecting player yaw/pitch");
+        smoothCoastersRotationMode = config.get("smoothCoastersRotationMode", RotationMode.class, RotationMode.PLAYER);
     }
 
     public static void putParsers(String key, ItemParser[] parsersArr) {

--- a/src/main/java/com/bergerkiller/bukkit/tc/attachments/control/seat/FirstPersonDefault.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/attachments/control/seat/FirstPersonDefault.java
@@ -1,5 +1,6 @@
 package com.bergerkiller.bukkit.tc.attachments.control.seat;
 
+import com.bergerkiller.bukkit.tc.TCConfig;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
@@ -52,7 +53,13 @@ public class FirstPersonDefault {
 
         if (this.useSmoothCoasters()) {
             Quaternion rotation = seat.getTransform().getRotation();
+            TrainCarts.plugin.getSmoothCoastersAPI().setRotationMode(
+                    null,
+                    viewer,
+                    TCConfig.smoothCoastersRotationMode
+            );
             TrainCarts.plugin.getSmoothCoastersAPI().setRotation(
+                    null,
                     viewer,
                     (float) rotation.getX(),
                     (float) rotation.getY(),
@@ -101,7 +108,7 @@ public class FirstPersonDefault {
     public void makeHidden(Player viewer) {
         if (TrainCarts.plugin.isEnabled()) {
             // Cannot send plugin messages while the plugin is being disabled
-            TrainCarts.plugin.getSmoothCoastersAPI().resetRotation(viewer);
+            TrainCarts.plugin.getSmoothCoastersAPI().resetRotation(null, viewer);
         }
 
         if (this._fakeCameraMount != null) {
@@ -117,6 +124,7 @@ public class FirstPersonDefault {
         if (this.useSmoothCoasters()) {
             Quaternion rotation = seat.getTransform().getRotation();
             TrainCarts.plugin.getSmoothCoastersAPI().setRotation(
+                    null,
                     _player,
                     (float) rotation.getX(),
                     (float) rotation.getY(),


### PR DESCRIPTION
CAMERA mode rotates the camera without changing the yaw/pitch of the player. This causes unfixable bugs like broken nametag and particle rendering and causes problems when right-clicking things (since you're not actually looking at them).

PLAYER mode rotates the player: The client changes its own yaw/pitch according to the camera rotation. This fixes the bugs caused by camera mode.

This changes the default from CAMERA to the new PLAYER mode. The mode can be changed back in the config if it causes problems (anti-cheat plugins might not like how players rotate their head).