### PR TITLE
Update SmoothCoasters support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>me.m56738</groupId>
             <artifactId>SmoothCoastersAPI</artifactId>
-            <version>1.6</version>
+            <version>1.8</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- [x] Update SmoothCoastersAPI (introduces protocol [V4](https://github.com/56738/SmoothCoasters/blob/master/src/main/java/me/m56738/smoothcoasters/implementation/ImplV4.java))
- [x] Use player rotation mode (fixes many bugs like particle rendering)
- [x] Use rotation limit for locked body rotation
- [ ] Use rotation limit for view locking

Removes support for older versions of the mod. The latest version contains important fixes and has been backported to 1.16.5, 1.17.1 and 1.18.2 in addition to 1.19.