### PR TITLE
Remove some assumptions about the type of the attachment controller

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/tc/attachments/api/AttachmentInternalState.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/attachments/api/AttachmentInternalState.java
@@ -233,7 +233,8 @@ public class AttachmentInternalState {
             lastAnimationState = null;
         } else if (!currentAnimation.hasReachedEnd()) {
             // TODO: Do we need dt here?
-            double dt = ((CartAttachment) attachment).getController().getAnimationDeltaTime();
+            final CartAttachment cart = (CartAttachment) attachment;
+            double dt = cart.hasController() ? cart.getController().getAnimationDeltaTime() : 1.0 / 20;
             AnimationNode animNode = currentAnimation.update(dt, initialTransform);
             if (animNode != null) {
                 lastAnimationState = animNode;

--- a/src/main/java/com/bergerkiller/bukkit/tc/attachments/api/AttachmentManager.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/attachments/api/AttachmentManager.java
@@ -1,6 +1,9 @@
 package com.bergerkiller.bukkit.tc.attachments.api;
 
 import com.bergerkiller.bukkit.common.config.ConfigurationNode;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
 
 /**
  * Manages one or more trees of attachments on a more general level.
@@ -23,6 +26,11 @@ public interface AttachmentManager {
      * @return world
      */
     org.bukkit.World getWorld();
+
+    /**
+     * Gets the players who can currently view the attachments
+     */
+    Collection<Player> getViewers();
 
     /**
      * Gets the {@link AttachmentTypeRegistry} used to find and create new attachments from

--- a/src/main/java/com/bergerkiller/bukkit/tc/attachments/control/CartAttachment.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/attachments/control/CartAttachment.java
@@ -38,7 +38,11 @@ public abstract class CartAttachment implements Attachment {
 
     @Override
     public Collection<Player> getViewers() {
-        return this.getController().getViewers();
+        return this.getManager().getViewers();
+    }
+
+    public boolean hasController() {
+        return this.getManager() instanceof AttachmentControllerMember;
     }
 
     /**

--- a/src/main/java/com/bergerkiller/bukkit/tc/attachments/control/CartAttachmentEntity.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/attachments/control/CartAttachmentEntity.java
@@ -236,7 +236,7 @@ public class CartAttachmentEntity extends CartAttachment {
             entityType = EntityType.MINECART;
         }
 
-        if (this.getParent() != null || !VirtualEntity.isMinecart(entityType) || hasCustomName) {
+        if (this.getParent() != null || !VirtualEntity.isMinecart(entityType) || hasCustomName || !hasController()) {
             // Generate entity (UU)ID
             this.entity = new VirtualEntity(this.getManager());
         } else {

--- a/src/main/java/com/bergerkiller/bukkit/tc/controller/components/AttachmentControllerMember.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/controller/components/AttachmentControllerMember.java
@@ -481,6 +481,7 @@ public class AttachmentControllerMember implements AttachmentModelOwner, Attachm
      *
      * @return viewers
      */
+    @Override
     public Set<Player> getViewers() {
         return this.viewers;
     }


### PR DESCRIPTION
Fixes some issues which prevent using a custom AttachmentManager:
* Add getViewers to AttachmentManager so other manager implementations can provide viewers too
* Make sure the manager is a controller (hasController) before casting