### PR TITLE
Fix SmoothCoasters bundle packet race condition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         <dependency>
             <groupId>me.m56738</groupId>
             <artifactId>SmoothCoastersAPI</artifactId>
-            <version>1.8</version>
+            <version>1.9</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/com/bergerkiller/bukkit/tc/controller/global/PacketQueue.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/controller/global/PacketQueue.java
@@ -138,9 +138,12 @@ public class PacketQueue implements AttachmentViewer, me.m56738.smoothcoasters.a
             throw new IllegalArgumentException("Wrong network interface used, interface is of " +
                     this.player.getName() + " but updated " + player.getName());
         }
-        //TODO: Seems Bundle packets break this, so send to queue directly and skip BundlerPacketQueue override
-        //send(PacketPlayOutCustomPayloadHandle.createNew(channel, message));
-        queue.put(PacketPlayOutCustomPayloadHandle.createNew(channel, message).toCommonPacket());
+        if (plugin.getSmoothCoastersAPI().getVersion(player) < 5) {
+            // Cannot use bundle packets with V4 because of a race condition
+            queue.put(PacketPlayOutCustomPayloadHandle.createNew(channel, message).toCommonPacket());
+        } else {
+            send(PacketPlayOutCustomPayloadHandle.createNew(channel, message));
+        }
     }
     /// --------------------------------------------------------------------
 


### PR DESCRIPTION
Bundle packets were sometimes being processed a tick too late.
Only use bundle packets if the player is using a version where this has been fixed.