### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Host the zip file somewhere on a FTP, your own server, a public resource pack ho
 This is the recommended way, as this way the train models also show properly inside the attachment editor.
 
 #### 2.B: Enable it in your client
-You can follow [this tutorial](https://minecraft.fandom.com/wiki/Tutorials/Loading_a_resource_pack) on the Minecraft Wiki to install the zip file as a resource pack in your Minecraft client.
+You can follow [this tutorial](https://minecraft.wiki/w/Tutorials/Loading_a_resource_pack) on the Minecraft Wiki to install the zip file as a resource pack in your Minecraft client.
 
 **Important note**: you will get a warning about the resource pack being outdated, but it works just fine on modern versions of Minecraft. That warning can be ignored.
 

--- a/src/main/java/com/bergerkiller/bukkit/tc/properties/standard/type/CollisionMobCategory.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/properties/standard/type/CollisionMobCategory.java
@@ -12,7 +12,7 @@ import com.bergerkiller.bukkit.tc.CollisionMode;
  * This enum contains entity types that a minecart could collide with.
  * This allows the user to configure collision modes in a very granular
  * fashion. The categories here are based on the minecraft wiki
- * (http://minecraft.gamepedia.com/Mobs#List_of_mobs) and in
+ * (http://minecraft.wiki/w/Mobs#List_of_mobs) and in
  * com.bergerkiller.bukkit.common.utils.EntityGroupingUtil.
  */
 public enum CollisionMobCategory {

--- a/src/main/java/com/bergerkiller/bukkit/tc/utils/SignBuildOptions.java
+++ b/src/main/java/com/bergerkiller/bukkit/tc/utils/SignBuildOptions.java
@@ -102,7 +102,7 @@ public class SignBuildOptions {
      * @return this
      */
     public SignBuildOptions setMinecraftWIKIHelp(String page) {
-        return setHelpURL("https://minecraft.gamepedia.com/" + page,
+        return setHelpURL("https://minecraft.wiki/w/" + page,
                 "Click here to visit the Minecraft WIKI for help with this sign");
     }
 


### PR DESCRIPTION
The Minecraft Fandom/Gamepedia wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.